### PR TITLE
Update protocol headers & API for firmware v266e

### DIFF
--- a/src/anki_util.c
+++ b/src/anki_util.c
@@ -50,12 +50,13 @@ void hexdump(const char *prefix, const size_t column_len, const void *value, siz
     int i;
 
     size_t slen = column_len*3;
-    char s[slen];
+    char* s = malloc(slen * sizeof(char));
     for (i = 0; i < row_count; ++i) {
-        memset(s, 0, column_len*3);
+        memset(s, 0, slen);
         bytes_to_hex(value, len, (char **)&s);
         printf("%s %s\n", prefix, s);
     }
+    free(s);
 }
 
 


### PR DESCRIPTION
Firmware version 266e is used in Overdrive v1.2.0.
These changes should also be backwards compatible with
older Overdrive firmware (back to v2667).

This protocol is NOT COMPATIBLE with firmware v2159.

CHANGES
=======

- Update protocol to support new TURN message & API.

- Add support for VEHICLE_CONFIG_PARAMS msg

This provides a way to provide a hint about the track material,
which affects the underlying camera parameters used for scan parsing.
It also provides a way to ignore the boost code embedded in
jump track pieces.

- Update Localization messages

- Expose road_piece_speed_limit flag for set_speed

This will currently be ignored when SDK_MODE is enabled.

- Update light-related message structs & API methods

It is now possible to send light info for up to 3 channels in a single message.
This reduces the number of commands required to set the main LED.

- Fix a hexdump helper method to malloc memory for string storage.

- Update vehicle-tool example to use new lights_pattern API.