### PR TITLE
fix cmake warning: rename "test" to "tests" target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,4 +28,4 @@ if (BUILD_EXAMPLES)
 endif ()
 
 # CTest is flaky - Create a target to run our test suite directly
-add_custom_target(test COMMAND ${PROJECT_BINARY_DIR}/test/Test)
+add_custom_target(tests COMMAND ${PROJECT_BINARY_DIR}/test/Test)

--- a/examples/vehicle-tool/vehicle_cmd.c
+++ b/examples/vehicle-tool/vehicle_cmd.c
@@ -665,7 +665,7 @@ anki_vehicle_light_effect_t get_effect_by_name(const char *name)
 
         uint8_t count = sizeof(effects_by_name)/sizeof(effects_by_name[0]);
         for (i = 0; i < count; i++) {
-                if (strncmp(name, effects_by_name[i], sizeof(effects_by_name[i])) == 0) {
+                if (strncmp(name, effects_by_name[i], strlen(effects_by_name[i])) == 0) {
                     effect = i;
                     break;
                 }
@@ -793,7 +793,7 @@ anki_vehicle_turn_type_t get_turn_type_by_name(const char *name)
 
         uint8_t count = sizeof(turn_types_by_name)/sizeof(turn_types_by_name[0]);
         for (i = 0; i < count; i++) {
-                if (strncmp(name, turn_types_by_name[i], sizeof(turn_types_by_name[i])) == 0) {
+                if (strncmp(name, turn_types_by_name[i], strlen(turn_types_by_name[i])) == 0) {
                     turn_type = (anki_vehicle_turn_type_t)i;
                     break;
                 }

--- a/examples/vehicle-tool/vehicle_tool.c
+++ b/examples/vehicle-tool/vehicle_tool.c
@@ -138,6 +138,9 @@ static GOptionEntry options[] = {
 	{ NULL },
 };
 
+int interactive(const char *src, const char *dst,
+            const char *dst_type, int psm);
+
 int main(int argc, char *argv[])
 {
 	GOptionContext *context;


### PR DESCRIPTION
The use of the name "test" for the test target causes a warning when cmake is invoked:

CMake Warning (dev) at deps/drive-sdk/CMakeLists.txt:31 (add_custom_target):
  Policy CMP0037 is not set: Target names should not be reserved and should
  match a validity pattern.  Run "cmake --help-policy CMP0037" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  The target name "test" is reserved or not valid for certain CMake features,
  such as generator expressions, and may result in undefined behavior.
This warning is for project developers.  Use -Wno-dev to suppress it.

By renaming the "test" target to "tests", we can avoid the warning
