### PR TITLE
fix clang warnings

### DIFF
--- a/examples/vehicle-tool/vehicle_cmd.c
+++ b/examples/vehicle-tool/vehicle_cmd.c
@@ -665,7 +665,7 @@ anki_vehicle_light_effect_t get_effect_by_name(const char *name)
 
         uint8_t count = sizeof(effects_by_name)/sizeof(effects_by_name[0]);
         for (i = 0; i < count; i++) {
-                if (strncmp(name, effects_by_name[i], sizeof(effects_by_name[i])) == 0) {
+                if (strncmp(name, effects_by_name[i], strlen(effects_by_name[i])) == 0) {
                     effect = i;
                     break;
                 }
@@ -793,7 +793,7 @@ anki_vehicle_turn_type_t get_turn_type_by_name(const char *name)
 
         uint8_t count = sizeof(turn_types_by_name)/sizeof(turn_types_by_name[0]);
         for (i = 0; i < count; i++) {
-                if (strncmp(name, turn_types_by_name[i], sizeof(turn_types_by_name[i])) == 0) {
+                if (strncmp(name, turn_types_by_name[i], strlen(turn_types_by_name[i])) == 0) {
                     turn_type = (anki_vehicle_turn_type_t)i;
                     break;
                 }

--- a/examples/vehicle-tool/vehicle_tool.c
+++ b/examples/vehicle-tool/vehicle_tool.c
@@ -138,6 +138,9 @@ static GOptionEntry options[] = {
 	{ NULL },
 };
 
+int interactive(const char *src, const char *dst,
+            const char *dst_type, int psm);
+
 int main(int argc, char *argv[])
 {
 	GOptionContext *context;


### PR DESCRIPTION
When compiling master with clang, three warnings were issued

```
drive-sdk/examples/vehicle-tool/vehicle_tool.c:159:2: warning: implicit declaration of function 'interactive' is invalid in C99 [-Wimplicit-function-declaration]
        interactive(opt_src, opt_dst, opt_dst_type, opt_psm);
        ^
1 warning generated.

drive-sdk/examples/vehicle-tool/vehicle_cmd.c:668:62: warning: 'strncmp' call operates on objects of type 'char' while the size is based on a different type 'char *' [-Wsizeof-pointer-memaccess]
                if (strncmp(name, effects_by_name[i], sizeof(effects_by_name[i])) == 0) {
                                  ~~~~~~~~~~~~~~~~~~         ^~~~~~~~~~~~~~~~~~
drive-sdk/examples/vehicle-tool/vehicle_cmd.c:668:62: note: did you mean to provide an explicit length?
                if (strncmp(name, effects_by_name[i], sizeof(effects_by_name[i])) == 0) {
                                                             ^~~~~~~~~~~~~~~~~~
drive-sdk/examples/vehicle-tool/vehicle_cmd.c:796:65: warning: 'strncmp' call operates on objects of type 'char' while the size is based on a different type 'char *' [-Wsizeof-pointer-memaccess]
                if (strncmp(name, turn_types_by_name[i], sizeof(turn_types_by_name[i])) == 0) {
                                  ~~~~~~~~~~~~~~~~~~~~~         ^~~~~~~~~~~~~~~~~~~~~
drive-sdk/examples/vehicle-tool/vehicle_cmd.c:796:65: note: did you mean to provide an explicit length?
                if (strncmp(name, turn_types_by_name[i], sizeof(turn_types_by_name[i])) == 0) {
                                                                ^~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
```

the attached two commits fix them